### PR TITLE
Fix crash on removed object properties 60568

### DIFF
--- a/ModelExplorerPlugin/EntityPropertyViewBuilder.cpp
+++ b/ModelExplorerPlugin/EntityPropertyViewBuilder.cpp
@@ -12,38 +12,44 @@
 
 
 EntityPropertyViewBuilder::EntityPropertyViewBuilder(
-    Renga::IParameterContainerPtr pParameters,
-    Renga::IPropertyContainerPtr pProperties,
-    Renga::IQuantityContainerPtr pQuantities,
+    ParameterContainerAccess parametersAccess,
+    PropertyContainerAccess propertiesAccess,
+    QuantityContainerAccess quantitiesAccess,
     bool disableProperties)
   : PropertyViewBuilderBase(disableProperties),
-    m_pParameters(pParameters),
-    m_pProperties(pProperties),
-    m_pQuantities(pQuantities)
+    m_parametersAccess(parametersAccess),
+    m_propertiesAccess(propertiesAccess),
+    m_quantitiesAccess(quantitiesAccess)
 {
 }
 
 void EntityPropertyViewBuilder::createParameters(PropertyManager& mngr, PropertyList& propertyList)
 {
   // TODO: remove this condition, devide class free functions
-  if (m_pParameters == nullptr)
+  auto pParameters = m_parametersAccess();
+  if (pParameters == nullptr)
     return;
 
-  auto properties = createParametersInternal(mngr, *m_pParameters);
+  auto properties = createParametersInternal(mngr, *pParameters);
   propertyList.splice(propertyList.end(), properties);
 }
 
 void EntityPropertyViewBuilder::createQuantities(PropertyManager& mngr, PropertyList& propertyList)
 {
   // TODO: remove this condition, devide class free functions
-  if (m_pQuantities == nullptr)
+  auto pQuantities = m_quantitiesAccess();
+  if (pQuantities == nullptr)
     return;
 
-  auto properties = createQuantitiesInternal(mngr, *m_pQuantities);
+  auto properties = createQuantitiesInternal(mngr, *pQuantities);
   propertyList.splice(propertyList.end(), properties);
 }
 
 PropertyList EntityPropertyViewBuilder::createProperties(PropertyManager& mngr)
 {
-  return createPropertiesInternal(mngr, m_pProperties);
+  auto pProperties = m_propertiesAccess();
+  if (pProperties == nullptr)
+    return PropertyList{};
+
+  return createPropertiesInternal(mngr, pProperties);
 }

--- a/ModelExplorerPlugin/EntityPropertyViewBuilder.cpp
+++ b/ModelExplorerPlugin/EntityPropertyViewBuilder.cpp
@@ -26,6 +26,9 @@ EntityPropertyViewBuilder::EntityPropertyViewBuilder(
 void EntityPropertyViewBuilder::createParameters(PropertyManager& mngr, PropertyList& propertyList)
 {
   // TODO: remove this condition, devide class free functions
+  if (!m_parametersAccess)
+    return;
+  
   auto pParameters = m_parametersAccess();
   if (pParameters == nullptr)
     return;
@@ -37,6 +40,9 @@ void EntityPropertyViewBuilder::createParameters(PropertyManager& mngr, Property
 void EntityPropertyViewBuilder::createQuantities(PropertyManager& mngr, PropertyList& propertyList)
 {
   // TODO: remove this condition, devide class free functions
+  if (!m_quantitiesAccess)
+    return;
+  
   auto pQuantities = m_quantitiesAccess();
   if (pQuantities == nullptr)
     return;
@@ -47,9 +53,12 @@ void EntityPropertyViewBuilder::createQuantities(PropertyManager& mngr, Property
 
 PropertyList EntityPropertyViewBuilder::createProperties(PropertyManager& mngr)
 {
+  if (!m_propertiesAccess)
+    return {};
+
   auto pProperties = m_propertiesAccess();
   if (pProperties == nullptr)
-    return PropertyList{};
+    return {};
 
   return createPropertiesInternal(mngr, pProperties);
 }

--- a/ModelExplorerPlugin/EntityPropertyViewBuilder.h
+++ b/ModelExplorerPlugin/EntityPropertyViewBuilder.h
@@ -9,15 +9,16 @@
 #pragma once
 
 #include "PropertyViewBuilderBase.h"
+#include "RengaModelUtils.h"
 
 
 class EntityPropertyViewBuilder : public PropertyViewBuilderBase
 {
 public:
   EntityPropertyViewBuilder(
-      Renga::IParameterContainerPtr pParameters,
-      Renga::IPropertyContainerPtr pProperties,
-      Renga::IQuantityContainerPtr pQuantities,
+      ParameterContainerAccess parametersAccess,
+      PropertyContainerAccess propertiesAccess,
+      QuantityContainerAccess quantitiesAccess,
       bool disableProperties);
 
   // IPropertyViewBuilder
@@ -26,7 +27,7 @@ public:
   PropertyList createProperties(PropertyManager& mng) override;
 
 protected:
-  Renga::IParameterContainerPtr m_pParameters;
-  Renga::IPropertyContainerPtr m_pProperties;
-  Renga::IQuantityContainerPtr m_pQuantities;
+  ParameterContainerAccess m_parametersAccess;
+  PropertyContainerAccess m_propertiesAccess;
+  QuantityContainerAccess m_quantitiesAccess;
 };

--- a/ModelExplorerPlugin/MaterialLayerPropertyViewBuilder.cpp
+++ b/ModelExplorerPlugin/MaterialLayerPropertyViewBuilder.cpp
@@ -6,25 +6,34 @@
 #include <Renga/QuantityIds.h>
 
 
-MaterialLayerPropertyViewBuilder::MaterialLayerPropertyViewBuilder(Renga::IApplicationPtr pApplication,
-                                                                   Renga::IMaterialLayerPtr pMaterialLayer,
-                                                                   Renga::ILayerPtr pLayer) :
-  m_pApplication(pApplication),
-  m_pMaterialLayer(pMaterialLayer),
-  m_pLayer(pLayer)
+MaterialLayerPropertyViewBuilder::MaterialLayerPropertyViewBuilder(
+    Renga::IApplicationPtr pApplication,
+    MaterialLayerAccess materialLayerAccess,
+    LayerAccess layerAccess)
+  : m_pApplication(pApplication),
+    m_materialLayerAccess(materialLayerAccess),
+    m_layerAccess(layerAccess)
 {
 }
 
 void MaterialLayerPropertyViewBuilder::createParameters(PropertyManager& mngr, PropertyList& propertyList)
 {
-  auto pMaterial = m_pMaterialLayer->GetMaterial();
+  auto pMaterialLayer = m_materialLayerAccess();
+  if (pMaterialLayer == nullptr)
+    return;
+
+  auto pMaterial = pMaterialLayer->GetMaterial();
   QString materialName = pMaterial != nullptr ? QString::fromWCharArray(pMaterial->Name) : QApplication::translate("me_materialLayer", "noMaterial");
   mngr.addValue(propertyList, QApplication::translate("me_materialLayer", "material"), materialName);
 }
 
 void MaterialLayerPropertyViewBuilder::createQuantities(PropertyManager& mngr, PropertyList& propertyList)
 {
-  auto pQuantities = m_pLayer->GetQuantities();
+  auto pLayer = m_layerAccess();
+  if (pLayer == nullptr)
+    return;
+
+  auto pQuantities = pLayer->GetQuantities();
   auto properties = createQuantitiesInternal(mngr, *pQuantities);
   propertyList.splice(propertyList.end(), properties);
 }

--- a/ModelExplorerPlugin/MaterialLayerPropertyViewBuilder.h
+++ b/ModelExplorerPlugin/MaterialLayerPropertyViewBuilder.h
@@ -1,20 +1,21 @@
 #pragma once
 
 #include "PropertyViewBuilderBase.h"
+#include "RengaModelUtils.h"
 
 
 class MaterialLayerPropertyViewBuilder : public PropertyViewBuilderBase
 {
 public:
   MaterialLayerPropertyViewBuilder(Renga::IApplicationPtr pApplication,
-                                   Renga::IMaterialLayerPtr pMaterialLayer,
-                                   Renga::ILayerPtr pLayer);
+                                   MaterialLayerAccess materialLayerAccess,
+                                   LayerAccess layer);
 
   void createParameters(PropertyManager& mngr, PropertyList& propertyList) override;
   void createQuantities(PropertyManager& mngr, PropertyList& propertyList) override;
 
 private:
   Renga::IApplicationPtr m_pApplication;
-  Renga::IMaterialLayerPtr m_pMaterialLayer;
-  Renga::ILayerPtr m_pLayer;
+  MaterialLayerAccess m_materialLayerAccess;
+  LayerAccess m_layerAccess;
 };

--- a/ModelExplorerPlugin/ModelExplorerPlugin.vcxproj
+++ b/ModelExplorerPlugin/ModelExplorerPlugin.vcxproj
@@ -112,7 +112,7 @@ copy /y "$(ProjectDir)Resources\ModelExplorerIcon.png" "$(OutDir)ModelExplorerIc
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="BoolGuard.cpp" />
+    <ClCompile Include="ScopeGuard.cpp" />
     <ClCompile Include="GeneratedFiles\Debug\moc_ModelExplorerButtonHandler.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -186,7 +186,7 @@ copy /y "$(ProjectDir)Resources\ModelExplorerIcon.png" "$(OutDir)ModelExplorerIc
     <ClCompile Include="TreeViewUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="BoolGuard.h" />
+    <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="GeneratedFiles\ui_ModelExplorer.h" />
     <ClInclude Include="GuidMap.h" />
     <ClInclude Include="GuidUtils.h" />

--- a/ModelExplorerPlugin/ModelExplorerPlugin.vcxproj.filters
+++ b/ModelExplorerPlugin/ModelExplorerPlugin.vcxproj.filters
@@ -104,9 +104,6 @@
       <Filter>RengaEvents</Filter>
     </ClCompile>
     <ClCompile Include="stdafx.cpp" />
-    <ClCompile Include="BoolGuard.cpp">
-      <Filter>Common</Filter>
-    </ClCompile>
     <ClCompile Include="GuidUtils.cpp">
       <Filter>Common</Filter>
     </ClCompile>
@@ -149,6 +146,9 @@
     <ClCompile Include="EntityPropertyViewBuilder.cpp">
       <Filter>ModelExplorerWidget\PropertyView</Filter>
     </ClCompile>
+    <ClCompile Include="ScopeGuard.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GeneratedFiles\ui_ModelExplorer.h">
@@ -157,9 +157,6 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="RengaObjectVisibility.h">
       <Filter>ModelExplorerWidget\TreeView</Filter>
-    </ClInclude>
-    <ClInclude Include="BoolGuard.h">
-      <Filter>Common</Filter>
     </ClInclude>
     <ClInclude Include="GuidUtils.h">
       <Filter>Common</Filter>
@@ -211,6 +208,9 @@
     </ClInclude>
     <ClInclude Include="GuidMap.h">
       <Filter>Generated Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ScopeGuard.h">
+      <Filter>Common</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/ModelExplorerPlugin/ModelExplorerWidget.cpp
+++ b/ModelExplorerPlugin/ModelExplorerWidget.cpp
@@ -7,21 +7,19 @@
 //
 
 #include "stdafx.h"
+
+#include "ScopeGuard.h"
+#include "EntityPropertyViewBuilder.h"
+#include "MaterialLayerPropertyViewBuilder.h"
 #include "ModelExplorerWidget.h"
-
-#include "ui_ModelExplorer.h"
-
+#include "RebarUsagePropertyViewBuilder.h"
+#include "ReinforcementUnitUsagePropertyViewBuilder.h"
+#include "RengaModelUtils.h"
 #include "TreeViewItemRole.h"
 #include "TreeViewItemType.h"
 #include "TreeViewModelBuilder.h"
 #include "TreeViewUtils.h"
-#include "BoolGuard.h"
-
-#include "MaterialLayerPropertyViewBuilder.h"
-#include "RebarUsagePropertyViewBuilder.h"
-#include "ReinforcementUnitUsagePropertyViewBuilder.h"
-#include "EntityPropertyViewBuilder.h"
-#include "RengaModelUtils.h"
+#include "ui_ModelExplorer.h"
 
 #include <Renga/ObjectTypes.h>
 

--- a/ModelExplorerPlugin/ModelExplorerWidget.cpp
+++ b/ModelExplorerPlugin/ModelExplorerWidget.cpp
@@ -374,16 +374,23 @@ void ModelExplorerWidget::onModelObjectSelected(const QModelIndex& index)
     assert(false);
 
   auto pModelObject = getModelObject(modelObjectId);
-  assert(pModelObject != nullptr);
+  if (pModelObject == nullptr)
+    return;
 
   auto builder = std::make_unique<EntityPropertyViewBuilder>(
       pModelObject->GetParameters(),
       pModelObject->GetProperties(),
       pModelObject->GetQuantities(),
       false);
+
+  auto propertiesAccess = [this, modelObjectId]() 
+  { 
+    auto pObject = getModelObject(modelObjectId);
+    return pObject != nullptr ? pObject->GetProperties() : nullptr;
+  };
+
   m_pPropertyView->showProperties(std::move(builder),
-                                  pModelObject->GetParameters(),
-                                  pModelObject->GetProperties());
+                                  propertiesAccess);
 }
 
 void ModelExplorerWidget::onMaterialLayerSelected(const QModelIndex& index)
@@ -406,7 +413,7 @@ void ModelExplorerWidget::onMaterialLayerSelected(const QModelIndex& index)
 
   auto builder = std::make_unique<MaterialLayerPropertyViewBuilder>(m_pApplication, pMaterialLayer, pLayer);;
 
-  m_pPropertyView->showProperties(std::move(builder), nullptr, nullptr);
+  m_pPropertyView->showProperties(std::move(builder), nullptr);
 }
 
 void ModelExplorerWidget::onRebarUsageSelected(const QModelIndex& index)
@@ -435,7 +442,7 @@ void ModelExplorerWidget::onRebarUsageSelected(const QModelIndex& index)
 
   auto builder = std::make_unique<RebarUsagePropertyViewBuilder>(m_pApplication, pRebarUsage);
 
-  m_pPropertyView->showProperties(std::move(builder), nullptr, nullptr);
+  m_pPropertyView->showProperties(std::move(builder), nullptr);
 }
 
 void ModelExplorerWidget::onReinforcementUnitUsageSelected(const QModelIndex& index)
@@ -458,7 +465,7 @@ void ModelExplorerWidget::onReinforcementUnitUsageSelected(const QModelIndex& in
 
   auto builder = std::make_unique<ReinforcementUnitUsagePropertyViewBuilder>(m_pApplication, pReinforcementUnitUsage);
 
-  m_pPropertyView->showProperties(std::move(builder), nullptr, nullptr);
+  m_pPropertyView->showProperties(std::move(builder), nullptr);
 }
 
 void ModelExplorerWidget::onStyleSelected(const QModelIndex & index)
@@ -487,9 +494,20 @@ void ModelExplorerWidget::onStyleSelected(const QModelIndex & index)
     properties,
     nullptr,
     true);
+
+  auto propertiesAccess = [entityId, pEntityCollection]() -> Renga::IPropertyContainerPtr
+  {
+    auto pEntity = pEntityCollection->GetById(entityId);
+    if (pEntity == nullptr)
+      return nullptr;
+
+    auto properties = Renga::IPropertyContainerPtr();
+    pEntity->QueryInterface(&properties);
+    return properties;
+  };
+
   m_pPropertyView->showProperties(std::move(builder),
-                                  parameters,
-                                  properties);
+                                  propertiesAccess);
 }
 
 Renga::IModelObjectPtr ModelExplorerWidget::getModelObject(int id)

--- a/ModelExplorerPlugin/ModelExplorerWidget.cpp
+++ b/ModelExplorerPlugin/ModelExplorerWidget.cpp
@@ -404,24 +404,27 @@ void ModelExplorerWidget::onModelObjectSelected(const QModelIndex& index)
 void ModelExplorerWidget::onMaterialLayerSelected(const QModelIndex& index)
 {
   int modelObjectId = 0;
+  int layerIndex = 0;
 
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::EntityId, modelObjectId))
     assert(false);
 
-  auto pModelObject = getModelObject(modelObjectId);
-  if (pModelObject == nullptr)
-    return;
-
-  int layerIndex = 0;
-
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::LayerIndex, layerIndex))
     assert(false);
+
+  auto materialLayerAccess = [this, modelObjectId, layerIndex]()
+  {
+    auto pModelObject = getModelObject(modelObjectId);
+    return pModelObject != nullptr ? getMaterialLayer(pModelObject, layerIndex) : nullptr;
+  };
   
-  auto pMaterialLayer = getMaterialLayer(pModelObject, layerIndex);
-  auto pLayer = getLayer(pModelObject, layerIndex);
+  auto layerAccess = [this, modelObjectId, layerIndex]()
+  {
+    auto pModelObject = getModelObject(modelObjectId);
+    return pModelObject != nullptr ? getLayer(pModelObject, layerIndex) : nullptr;
+  };
 
-  auto builder = std::make_unique<MaterialLayerPropertyViewBuilder>(m_pApplication, pMaterialLayer, pLayer);
-
+  auto builder = std::make_unique<MaterialLayerPropertyViewBuilder>(m_pApplication, materialLayerAccess, layerAccess);
   m_pPropertyView->showProperties(std::move(builder), nullptr);
 }
 

--- a/ModelExplorerPlugin/ModelExplorerWidget.cpp
+++ b/ModelExplorerPlugin/ModelExplorerWidget.cpp
@@ -430,16 +430,12 @@ void ModelExplorerWidget::onMaterialLayerSelected(const QModelIndex& index)
 
 void ModelExplorerWidget::onRebarUsageSelected(const QModelIndex& index)
 {
-  int modelObjectId = 0;
+  int modelObjectId = 0, reinforcementUnitStyleId = 0, rebarUsageIndex = 0;
 
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::EntityId, modelObjectId))
     assert(false);
 
-  int reinforcementUnitStyleId = 0;
-
   tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::ReinforcementUnitStyleId, reinforcementUnitStyleId);
-
-  int rebarUsageIndex = 0;
 
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::RebarUsageIndex, rebarUsageIndex))
     assert(false);
@@ -462,24 +458,21 @@ void ModelExplorerWidget::onRebarUsageSelected(const QModelIndex& index)
 
 void ModelExplorerWidget::onReinforcementUnitUsageSelected(const QModelIndex& index)
 {
-  int modelObjectId = 0;
+  int modelObjectId, reinforcementUnitUsageIndex = 0;
 
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::EntityId, modelObjectId))
     assert(false);
 
-  auto pModelObject = getModelObject(modelObjectId);
-  if (pModelObject == nullptr)
-    return;
-
-  int reinforcementUnitUsageIndex = 0;
-
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::ReinforcementUnitUsageIndex, reinforcementUnitUsageIndex))
     assert(false);
 
-  auto pReinforcementUnitUsage = getReinforcementUnitUsage(pModelObject, reinforcementUnitUsageIndex);
-  assert(pReinforcementUnitUsage != nullptr);
+  auto reinforcementUnitUsageAccess = [this, modelObjectId, reinforcementUnitUsageIndex]()
+  {
+    auto pModelObject = getModelObject(modelObjectId);
+    return pModelObject != nullptr ? getReinforcementUnitUsage(pModelObject, reinforcementUnitUsageIndex) : nullptr;
+  };
 
-  auto builder = std::make_unique<ReinforcementUnitUsagePropertyViewBuilder>(m_pApplication, pReinforcementUnitUsage);
+  auto builder = std::make_unique<ReinforcementUnitUsagePropertyViewBuilder>(m_pApplication, reinforcementUnitUsageAccess);
 
   m_pPropertyView->showProperties(std::move(builder), nullptr);
 }

--- a/ModelExplorerPlugin/ModelExplorerWidget.cpp
+++ b/ModelExplorerPlugin/ModelExplorerWidget.cpp
@@ -435,10 +435,6 @@ void ModelExplorerWidget::onRebarUsageSelected(const QModelIndex& index)
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::EntityId, modelObjectId))
     assert(false);
 
-  auto pModelObject = getModelObject(modelObjectId);
-  if (pModelObject == nullptr)
-    return;
-
   int reinforcementUnitStyleId = 0;
 
   tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::ReinforcementUnitStyleId, reinforcementUnitStyleId);
@@ -448,12 +444,18 @@ void ModelExplorerWidget::onRebarUsageSelected(const QModelIndex& index)
   if (!tryGetIntegerData(m_pTreeViewModel.get(), index, eTreeViewItemRole::RebarUsageIndex, rebarUsageIndex))
     assert(false);
 
-  Renga::IRebarUsagePtr pRebarUsage = reinforcementUnitStyleId != 0 ?
-    getRebarUsage(reinforcementUnitStyleId, rebarUsageIndex) :
-    getRebarUsage(pModelObject, rebarUsageIndex);
-  assert(pRebarUsage != nullptr);
+  auto rebarUsageAccess = [this, modelObjectId, reinforcementUnitStyleId, rebarUsageIndex]() -> Renga::IRebarUsagePtr
+  {
+    auto pModelObject = getModelObject(modelObjectId);
+    if (pModelObject == nullptr)
+      return nullptr;
 
-  auto builder = std::make_unique<RebarUsagePropertyViewBuilder>(m_pApplication, pRebarUsage);
+    return reinforcementUnitStyleId != 0 ?
+      getRebarUsage(reinforcementUnitStyleId, rebarUsageIndex) :
+      getRebarUsage(pModelObject, rebarUsageIndex);
+  };
+
+  auto builder = std::make_unique<RebarUsagePropertyViewBuilder>(m_pApplication, rebarUsageAccess);
 
   m_pPropertyView->showProperties(std::move(builder), nullptr);
 }

--- a/ModelExplorerPlugin/PropertyView.h
+++ b/ModelExplorerPlugin/PropertyView.h
@@ -10,11 +10,10 @@
 #include "PropertyManager.h"
 #include "IPropertyViewBuilder.h"
 #include "IPropertyViewSourceObject.h"
+#include "RengaModelUtils.h"
 
 #include <qttreepropertybrowser.h>
 
-
-using PropertyContainerAccess = std::function<Renga::IPropertyContainerPtr()>;
 
 class PropertyView : public QtTreePropertyBrowser
 {

--- a/ModelExplorerPlugin/PropertyView.h
+++ b/ModelExplorerPlugin/PropertyView.h
@@ -14,6 +14,8 @@
 #include <qttreepropertybrowser.h>
 
 
+using PropertyContainerAccess = std::function<Renga::IPropertyContainerPtr()>;
+
 class PropertyView : public QtTreePropertyBrowser
 {
   Q_OBJECT
@@ -27,23 +29,14 @@ public:
 
   PropertyView(QWidget* pParent, Renga::IApplicationPtr pApplication);
 
-  void showProperties(std::unique_ptr<IPropertyViewBuilder> builder,
-                      Renga::IParameterContainerPtr parameters,
-                      Renga::IPropertyContainerPtr properties);
-
+  void showProperties(std::unique_ptr<IPropertyViewBuilder> builder, PropertyContainerAccess propertiesAccess);
   void changeMode(PropertyView::Mode newMode);
 
 private slots:
   void userDoubleAttributeChanged(QtProperty* property, const QString& newValue);
   void userStringAttributeChanged(QtProperty* property, const QString& newValue);
 
-  void parameterBoolChanged(QtProperty* pProperty, bool val);
-  void parameterIntChanged(QtProperty* pProperty, int val);
-  void parameterDoubleChanged(QtProperty* pProperty, const QString& newValue);
-  void parameterStringChanged(QtProperty* pProperty, const QString& newValue);
-
 private:
-  void updateParameters();
   void initPropertyManagers();
   void clearPropertyManagers();
   
@@ -63,6 +56,5 @@ private:
   Mode m_propertyViewMode;
 
   std::unique_ptr<IPropertyViewBuilder> m_builder;
-  Renga::IPropertyContainerPtr m_properties;
-  Renga::IParameterContainerPtr m_parameters;
+  PropertyContainerAccess m_propertiesAccess;
 };

--- a/ModelExplorerPlugin/PropertyViewBuilderBase.cpp
+++ b/ModelExplorerPlugin/PropertyViewBuilderBase.cpp
@@ -3,29 +3,9 @@
 #include "PropertyViewBuilderBase.h"
 #include "PropertyManager.h"
 #include "GuidUtils.h"
+#include "ScopeGuard.h"
 
 #include <Renga/QuantityIds.h>
-
-
-namespace
-{
-  template <typename TFunc>
-  class CActionGuard
-  {
-  public:
-    CActionGuard(const TFunc& func) : m_func(func) {}
-    ~CActionGuard() { m_func(); }
-
-  private:
-    TFunc m_func;
-  };
-
-  template <typename TFunc>
-  CActionGuard<TFunc> makeGuard(const TFunc& func)
-  {
-    return CActionGuard<TFunc>(func);
-  }
-}
 
 
 PropertyViewBuilderBase::PropertyViewBuilderBase(bool disableProperties) : m_disableProperties(disableProperties)

--- a/ModelExplorerPlugin/RebarUsagePropertyViewBuilder.cpp
+++ b/ModelExplorerPlugin/RebarUsagePropertyViewBuilder.cpp
@@ -7,15 +7,19 @@
 
 
 RebarUsagePropertyViewBuilder::RebarUsagePropertyViewBuilder(Renga::IApplicationPtr pApplication,
-                                                             Renga::IRebarUsagePtr pRebarUsage) :
+                                                             RebarUsageAccess rebarUsageAccess) :
   m_pApplication(pApplication),
-  m_pRebarUsage(pRebarUsage)
+  m_rebarUsageAccess(rebarUsageAccess)
 {
 }
 
 void RebarUsagePropertyViewBuilder::createParameters(PropertyManager& mngr, PropertyList& propertyList)
 {
-  auto pRebarStyle = getRebarStyle(m_pRebarUsage->StyleId);
+  auto pRebarUsage = m_rebarUsageAccess();
+  if (pRebarUsage == nullptr)
+    return;
+
+  auto pRebarStyle = getRebarStyle(pRebarUsage->StyleId);
 
   if (pRebarStyle != nullptr)
     mngr.addValue(propertyList, QApplication::translate("me_reinforcement", "name"), QString::fromWCharArray(pRebarStyle->Name));
@@ -25,7 +29,11 @@ void RebarUsagePropertyViewBuilder::createQuantities(PropertyManager& mngr, Prop
 {
   using namespace Renga;
 
-  auto pQuantities = m_pRebarUsage->GetQuantities();
+  auto pRebarUsage = m_rebarUsageAccess();
+  if (pRebarUsage == nullptr)
+    return;
+
+  auto pQuantities = pRebarUsage->GetQuantities();
 
   mngr.addValue(propertyList, QApplication::translate("me_reinforcement", "count"), pQuantities->Get(QuantityIds::Count));
   mngr.addValue(propertyList, QApplication::translate("me_reinforcement", "nominalLength"), pQuantities->Get(QuantityIds::NominalLength));

--- a/ModelExplorerPlugin/RebarUsagePropertyViewBuilder.h
+++ b/ModelExplorerPlugin/RebarUsagePropertyViewBuilder.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "IPropertyViewBuilder.h"
+#include "RengaModelUtils.h"
 
 
 class RebarUsagePropertyViewBuilder : public IPropertyViewBuilder
 {
 public:
   RebarUsagePropertyViewBuilder(Renga::IApplicationPtr pApplication,
-                                Renga::IRebarUsagePtr pRebarUsage);
+                                RebarUsageAccess rebarUsageAccess);
 
   void createParameters(PropertyManager& mngr, PropertyList& propertyList) override;
   void createQuantities(PropertyManager& mngr, PropertyList& propertyList) override;
@@ -17,5 +18,5 @@ private:
 
 private:
   Renga::IApplicationPtr m_pApplication;
-  Renga::IRebarUsagePtr m_pRebarUsage;
+  RebarUsageAccess m_rebarUsageAccess;
 };

--- a/ModelExplorerPlugin/ReinforcementUnitUsagePropertyViewBuilder.cpp
+++ b/ModelExplorerPlugin/ReinforcementUnitUsagePropertyViewBuilder.cpp
@@ -6,16 +6,21 @@
 #include <Renga/QuantityIds.h>
 
 
-ReinforcementUnitUsagePropertyViewBuilder::ReinforcementUnitUsagePropertyViewBuilder(Renga::IApplicationPtr pApplication,
-                                                                                     Renga::IReinforcementUnitUsagePtr pReinforcementUnitUsage) :
-  m_pApplication(pApplication),
-  m_pReinforcementUnitUsage(pReinforcementUnitUsage)
+ReinforcementUnitUsagePropertyViewBuilder::ReinforcementUnitUsagePropertyViewBuilder(
+    Renga::IApplicationPtr pApplication,
+    ReinforcementUnitUsageAccess reinforcementUnitUsageAccess)
+  : m_pApplication(pApplication),
+    m_reinforcementUnitUsageAccess(reinforcementUnitUsageAccess)
 {
 }
 
 void ReinforcementUnitUsagePropertyViewBuilder::createParameters(PropertyManager& mngr, PropertyList& propertyList)
 {
-  auto pReinforcementUnitStyle = getReinforcementUnitStyle(m_pReinforcementUnitUsage->StyleId);
+  auto pReinforcementUnitUsage = m_reinforcementUnitUsageAccess();
+  if (pReinforcementUnitUsage == nullptr)
+    return;
+
+  auto pReinforcementUnitStyle = getReinforcementUnitStyle(pReinforcementUnitUsage->StyleId);
 
   if (pReinforcementUnitStyle != nullptr)
     mngr.addValue(propertyList, QApplication::translate("me_reinforcement", "name"), QString::fromWCharArray(pReinforcementUnitStyle->Name));
@@ -25,7 +30,11 @@ void ReinforcementUnitUsagePropertyViewBuilder::createQuantities(PropertyManager
 {
   using namespace Renga;
 
-  auto pQuantities = m_pReinforcementUnitUsage->GetQuantities();
+  auto pReinforcementUnitUsage = m_reinforcementUnitUsageAccess();
+  if (pReinforcementUnitUsage == nullptr)
+    return;
+
+  auto pQuantities = pReinforcementUnitUsage->GetQuantities();
 
   mngr.addValue(propertyList, QApplication::translate("me_reinforcement", "totalRebarLength"), pQuantities->Get(QuantityIds::TotalRebarLength));
   mngr.addValue(propertyList, QApplication::translate("me_reinforcement", "totalRebarMass"), pQuantities->Get(QuantityIds::TotalRebarMass));

--- a/ModelExplorerPlugin/ReinforcementUnitUsagePropertyViewBuilder.h
+++ b/ModelExplorerPlugin/ReinforcementUnitUsagePropertyViewBuilder.h
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "IPropertyViewBuilder.h"
+#include "RengaModelUtils.h"
 
 
 class ReinforcementUnitUsagePropertyViewBuilder : public IPropertyViewBuilder
 {
 public:
-  ReinforcementUnitUsagePropertyViewBuilder(Renga::IApplicationPtr pApplication,
-                                            Renga::IReinforcementUnitUsagePtr pReinforcementUnitUsage);
+  ReinforcementUnitUsagePropertyViewBuilder(
+      Renga::IApplicationPtr pApplication,
+      ReinforcementUnitUsageAccess reinforcementUnitUsageAccess);
 
   void createParameters(PropertyManager& mngr, PropertyList& propertyList) override;
   void createQuantities(PropertyManager& mngr, PropertyList& propertyList) override;
@@ -17,5 +19,5 @@ private:
 
 private:
   Renga::IApplicationPtr m_pApplication;
-  Renga::IReinforcementUnitUsagePtr m_pReinforcementUnitUsage;
+  ReinforcementUnitUsageAccess m_reinforcementUnitUsageAccess;
 };

--- a/ModelExplorerPlugin/RengaModelUtils.h
+++ b/ModelExplorerPlugin/RengaModelUtils.h
@@ -4,3 +4,7 @@
 
 
 Renga::IEntityCollectionPtr getProjectEntityCollection(Renga::IProjectPtr pProject, GUID entityType);
+
+using PropertyContainerAccess = std::function<Renga::IPropertyContainerPtr()>;
+using ParameterContainerAccess = std::function<Renga::IParameterContainerPtr()>;
+using QuantityContainerAccess = std::function<Renga::IQuantityContainerPtr()>;

--- a/ModelExplorerPlugin/RengaModelUtils.h
+++ b/ModelExplorerPlugin/RengaModelUtils.h
@@ -10,3 +10,4 @@ using ParameterContainerAccess = std::function<Renga::IParameterContainerPtr()>;
 using QuantityContainerAccess = std::function<Renga::IQuantityContainerPtr()>;
 using MaterialLayerAccess = std::function<Renga::IMaterialLayerPtr()>;
 using LayerAccess = std::function<Renga::ILayerPtr()>;
+using RebarUsageAccess = std::function<Renga::IRebarUsagePtr()>;

--- a/ModelExplorerPlugin/RengaModelUtils.h
+++ b/ModelExplorerPlugin/RengaModelUtils.h
@@ -8,3 +8,5 @@ Renga::IEntityCollectionPtr getProjectEntityCollection(Renga::IProjectPtr pProje
 using PropertyContainerAccess = std::function<Renga::IPropertyContainerPtr()>;
 using ParameterContainerAccess = std::function<Renga::IParameterContainerPtr()>;
 using QuantityContainerAccess = std::function<Renga::IQuantityContainerPtr()>;
+using MaterialLayerAccess = std::function<Renga::IMaterialLayerPtr()>;
+using LayerAccess = std::function<Renga::ILayerPtr()>;

--- a/ModelExplorerPlugin/RengaModelUtils.h
+++ b/ModelExplorerPlugin/RengaModelUtils.h
@@ -11,3 +11,4 @@ using QuantityContainerAccess = std::function<Renga::IQuantityContainerPtr()>;
 using MaterialLayerAccess = std::function<Renga::IMaterialLayerPtr()>;
 using LayerAccess = std::function<Renga::ILayerPtr()>;
 using RebarUsageAccess = std::function<Renga::IRebarUsagePtr()>;
+using ReinforcementUnitUsageAccess = std::function<Renga::IReinforcementUnitUsagePtr()>;

--- a/ModelExplorerPlugin/ScopeGuard.cpp
+++ b/ModelExplorerPlugin/ScopeGuard.cpp
@@ -7,7 +7,8 @@
 //
 
 #include "stdafx.h"
-#include "BoolGuard.h"
+#include "ScopeGuard.h"
+
 
 BoolGuard::BoolGuard(bool& variable)
   : m_variable(variable)

--- a/ModelExplorerPlugin/ScopeGuard.h
+++ b/ModelExplorerPlugin/ScopeGuard.h
@@ -27,7 +27,7 @@ template <typename TFunc>
 class CActionGuard
 {
 public:
-  CActionGuard(const TFunc& func) : m_func(func) {}
+  CActionGuard(TFunc&& func) : m_func(std::forward<TFunc>(func)) {}
   ~CActionGuard() { m_func(); }
 
 private:
@@ -35,7 +35,7 @@ private:
 };
 
 template <typename TFunc>
-CActionGuard<TFunc> makeGuard(const TFunc& func)
+CActionGuard<TFunc> makeGuard(TFunc&& func)
 {
-  return CActionGuard<TFunc>(func);
+  return CActionGuard<TFunc>(std::forward<TFunc>(func));
 }

--- a/ModelExplorerPlugin/ScopeGuard.h
+++ b/ModelExplorerPlugin/ScopeGuard.h
@@ -22,3 +22,20 @@ public:
 private:
   bool& m_variable;
 };
+
+template <typename TFunc>
+class CActionGuard
+{
+public:
+  CActionGuard(const TFunc& func) : m_func(func) {}
+  ~CActionGuard() { m_func(); }
+
+private:
+  TFunc m_func;
+};
+
+template <typename TFunc>
+CActionGuard<TFunc> makeGuard(const TFunc& func)
+{
+  return CActionGuard<TFunc>(func);
+}


### PR DESCRIPTION
Падения были из-за того, что мы обращались к объектам, бэкенд которых удален. Кажется единственный способ этого избежать при отсутствии событий - работать через запросы, т.е. нужен объект, спрашиваем, работаем.