### PR TITLE
Issue #40: fix critical crash when working with ohantom objects

### DIFF
--- a/ModelExplorerPlugin/RengaModelUtils.cpp
+++ b/ModelExplorerPlugin/RengaModelUtils.cpp
@@ -118,3 +118,15 @@ QString getEntityName(Renga::IProjectPtr pProject, GUID entityType, int entityId
   auto pEntity = pCollection->GetById(entityId);
   return pEntity ? QString::fromWCharArray(pEntity->Name) : QString{};
 }
+
+Renga::IModelObjectCollectionPtr getModelObjectsSafe(Renga::IModel& model)
+{
+  try
+  {
+    return model.GetObjects();
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}

--- a/ModelExplorerPlugin/RengaModelUtils.h
+++ b/ModelExplorerPlugin/RengaModelUtils.h
@@ -11,6 +11,10 @@ int getLogicalValueIndex(Renga::Logical value);
 Renga::Logical getLogicalValueFromIndex(int index);
 // INFO: works only for entities located directly in project (styles, materials, drawings, etc.)
 QString getEntityName(Renga::IProjectPtr pProject, GUID entityType, int entityId);
+// Renga may fail on pModel->GetObjects(); because of internal issue
+// when phantom objects are in the collection
+// Issue #40 workaround
+Renga::IModelObjectCollectionPtr getModelObjectsSafe(Renga::IModel& model);
 
 using PropertyContainerAccess = std::function<Renga::IPropertyContainerPtr()>;
 using ParameterContainerAccess = std::function<Renga::IParameterContainerPtr()>;

--- a/ModelExplorerPlugin/ScopeGuard.h
+++ b/ModelExplorerPlugin/ScopeGuard.h
@@ -14,8 +14,10 @@ public:
   explicit BoolGuard(bool& variable);
   explicit BoolGuard(bool& variable, bool initialValue);
 
-  BoolGuard(const BoolGuard& guard) = delete;
-  BoolGuard& operator = (const BoolGuard& guard) = delete;
+  BoolGuard(const BoolGuard& guard)            = delete;
+  BoolGuard(BoolGuard&& guard)                 = default;
+  BoolGuard& operator=(const BoolGuard& guard) = delete;
+  BoolGuard& operator=(BoolGuard&& guard)      = default;
 
   ~BoolGuard();
 


### PR DESCRIPTION
Renga (actually COM wrapper) throws exception in all cases when we call IModel::GetObjects() when there is a phantom object on scene.

Fix crash with workaroud - exeptions from Renga API suppressed.